### PR TITLE
[FIX] Fixes for sid demo composefile

### DIFF
--- a/examples/sid_visualization/docker-compose.yml
+++ b/examples/sid_visualization/docker-compose.yml
@@ -1,49 +1,63 @@
 version: "3"
 
+x-with-gpus: &with_gpus
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - capabilities:
+            - gpu
+
 services:
   triton:
     image: nvcr.io/nvidia/tritonserver:22.02-py3
+    <<: *with_gpus
     command: "tritonserver --exit-on-error=false --model-control-mode=explicit --load-model sid-minibert-onnx --model-repository=/models/triton-model-repo"
     environment:
-      NVIDIA_VISIBLE_DEVICES: "0"
+      NVIDIA_VISIBLE_DEVICES: "${NVIDIA_VISIBLE_DEVICES:-}"
     ports:
       - "8000"
       - "8001"
       - "8002"
-    runtime: nvidia
     volumes:
-      - "${MORPHEUS_HOME:?Must set MORPHEUS_HOME to the Morpheus repo directory}/models:/models"
+      - "${MORPHEUS_HOME:-../..}/models:/models"
 
   gui:
     image: sid-viz:latest
+    <<: *with_gpus
     build:
-      context: ./viz
-      # target: base
+      context: viz
+      args:
+        RAPIDSAI_GPU_ARCH: "${RAPIDSAI_GPU_ARCH:-}" # 60 | 70 | 75 | 80 | 86
     cap_add:
+      - SYS_ADMIN
       - SYS_PTRACE
-    command: yarn build_and_start
-    environment:
-      DBUS_SESSION_BUS_ADDRESS: "${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$UID/bus}"
-      DISPLAY: "${DISPLAY:-}"
-      NVIDIA_DRIVER_CAPABILITIES: all
-      TERM: "${TERM:-}" # Colorize the terminal in the container if possible
-      MORPHEUS_SOCKET_URL: "morpheus:8765"
-    stdin_open: true
-    tty: true
-    volumes:
-      # - ./viz:/opt/rapids/viz
-      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
-      - /tmp/.X11-unix:/tmp/.X11-unix
-      - ${XDG_RUNTIME_DIR:-/run/user/$UID}:${XDG_RUNTIME_DIR:-/run/user/$UID}
-    # network_mode: host
-    working_dir: /opt/rapids/viz
-    runtime: nvidia
     security_opt:
-      - seccomp=unconfined
       - apparmor=unconfined
+    environment:
+      NVIDIA_DRIVER_CAPABILITIES: all
+      MORPHEUS_SOCKET_URL: "morpheus:8765"
+      # Colorize the terminal in the container if possible
+      TERM: "${TERM:-}"
+      # Use the host's X11 display
+      DISPLAY: "${DISPLAY:-}"
+      XAUTHORITY: "${XAUTHORITY:-}"
+      XDG_SESSION_TYPE: "${XDG_SESSION_TYPE:-}"
+      XDG_RUNTIME_DIR: "${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR must be set}"
+      DBUS_SESSION_BUS_ADDRESS: "${DBUS_SESSION_BUS_ADDRESS:?DBUS_SESSION_BUS_ADDRESS must be set}"
+    volumes:
+      - "/etc/fonts:/etc/fonts:ro"
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/tmp/.X11-unix:/tmp/.X11-unix:rw"
+      - "/usr/share/fonts:/usr/share/fonts:ro"
+      - "/usr/share/icons:/usr/share/icons:ro"
+      - "${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR}"
+      - "/run/dbus/system_bus_socket:/run/dbus/system_bus_socket"
 
   morpheus:
     image: morpheus:sid-viz
+    <<: *with_gpus
     command: bash
     cap_add:
       - SYS_NICE
@@ -51,10 +65,11 @@ services:
       - gui
       - triton
     environment:
-      - BUILD_DIR=build-docker # Avoid conflicting with the host default build
+      BUILD_DIR: build-docker # Avoid conflicting with the host default build
+      NVIDIA_VISIBLE_DEVICES: "${NVIDIA_VISIBLE_DEVICES:-}"
     ports:
       - "8765"
     stdin_open: true
     tty: true
     volumes:
-      - "${MORPHEUS_HOME:?Must set MORPHEUS_HOME to the Morpheus repo directory}:/workspace"
+      - "${MORPHEUS_HOME:-../../}:/workspace"


### PR DESCRIPTION
* allow setting `NVIDIA_VISIBLE_DEVICES`
* ensure containers launch with nvidia runtime
* use new sid-viz Dockerfile

This PR lets a user with multiple GPUs control which ones triton/morpheus run on via envvar"
```shell
NVIDIA_VISIBLE_DEVICES=1 docker-compose up --build -d
```