### PR TITLE
Cache list of registered models, avoiding lookups for users which don't have models

### DIFF
--- a/examples/dfp_workflow/mlflow/Dockerfile
+++ b/examples/dfp_workflow/mlflow/Dockerfile
@@ -3,13 +3,13 @@ FROM python:3.8-slim-buster
 # Install curl for health check
 RUN apt update && \
     apt install -y --no-install-recommends \
-        curl && \
+        curl libyaml-cpp-dev libyaml-dev && \
     apt autoremove -y && \
     apt clean all && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Install python packages
-RUN pip install mlflow boto3 pymysql
+RUN pip install mlflow boto3 pymysql pyyaml
 
 # We run on port 5000
 EXPOSE 5000


### PR DESCRIPTION
This trims 1m off of inferencing 2 days of data

Also adds libyaml & PyYaml to docker image for mlflow.
Docs suggest this improves performance:
https://www.mlflow.org/docs/latest/tracking.html#file-store-performance

However it is unclear if this only refers to the backend file store (which we don't use) or if it also refers to the artifact store which we do use.